### PR TITLE
remove parenthesis from project name if present

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ cd $(dirname $0)
 . utils
 . ../../environment
 
-PROJECT=$(oc status | sed -n '1 { s/.* //; p; }')
+PROJECT=$(oc status | sed -n '1 { s/.* //; s/(//; s/)//;  p; }')
 
 oc create -f - <<EOF || true
 kind: ImageStream


### PR DESCRIPTION
When using an alias for project name, in my case infra was taken, the 'real' name is showed in parenthesis. Example:
$ oc status
In project infra (infra-jbrannst)

...
