### PR TITLE
Source url update

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ spec:
     type: Git
     git:
       ref: master
-      uri: http://gogs.$INFRA/$PROJECT/emailroute
+      uri: http://gogs.$DOMAIN/$PROJECT/emailroute
   output:
     to:
       name: emailroute

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,18 @@
 		<activemq-version>5.9.0</activemq-version>
 		<xbean-spring-version>3.15</xbean-spring-version>
 	</properties>
-
+	<repositories>
+		<repository>
+			<id>fusesource</id>
+			<url>http://repo.fusesource.com/nexus/content/groups/public/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 	<build>
 		<plugins>
 			<plugin>
@@ -90,7 +101,7 @@
 			<version>${activemq-version}</version>
 		</dependency>
 
-		<!-- xbean is required for ActiveMQ broker configuration in the spring 
+		<!-- xbean is required for ActiveMQ broker configuration in the spring
 			xml file -->
 		<dependency>
 			<groupId>org.apache.xbean</groupId>


### PR DESCRIPTION
When the build config is being created the domain in the source url was coming out as gogs.infra/

This fixes it to use the DOMAIN from the environment so it should come out as an addressable endpoint for the builder images.

Also added in the fusesource repo to the pom as if you don't have a mirror setup the build will fail. This shouldn't affect you if there is a mirror
